### PR TITLE
Enable creation of new project by clone

### DIFF
--- a/import_yocto_bm/config.py
+++ b/import_yocto_bm/config.py
@@ -17,6 +17,7 @@ parser.add_argument("--blackduck_api_token", type=str, help="Black Duck API toke
 parser.add_argument("--blackduck_trust_cert", help="Black Duck trust server cert", action='store_true')
 parser.add_argument("-p", "--project", help="Black Duck project to create (REQUIRED)", default="")
 parser.add_argument("-v", "--version", help="Black Duck project version to create (REQUIRED)", default="")
+parser.add_argument("-c", "--clone_version", help="Clone existing Black Duck project version", default="")
 parser.add_argument("-y", "--yocto_build_folder",
                     help="Yocto build folder (required if CVE check required or manifest file not specified)",
                     default=".")

--- a/import_yocto_bm/main.py
+++ b/import_yocto_bm/main.py
@@ -52,6 +52,10 @@ def main():
                 print(f'ERROR: Unable to connect to BD server {global_values.url}')
                 sys.exit(2)
 
+    if config.args.clone_version:
+        proj, clone_version = utils.get_projver(bd, config.args.project, config.args.clone_version)
+        utils.clone_version(bd, proj, clone_version, config.args.version)
+        
     if not config.args.cve_check_only:
         process.proc_yocto_project(config.args.manifest)
 
@@ -75,11 +79,11 @@ def main():
 
         try:
             print("- Reading Black Duck project ...")
-            proj, ver = utils.get_projver(bd, config.args)
+            proj, ver = utils.get_projver(bd, config.args.project, config.args.version)
             count = 1
             while ver is None:
                 time.sleep(10)
-                proj, ver = utils.get_projver(bd, config.args)
+                proj, ver = utils.get_projver(bd, config.args.project, config.args.version)
                 count += 1
                 if count > 20:
                     print(f"Unable to locate project {proj} and version '{ver}' - terminating")

--- a/import_yocto_bm/main.py
+++ b/import_yocto_bm/main.py
@@ -53,8 +53,10 @@ def main():
                 sys.exit(2)
 
     if config.args.clone_version:
-        proj, clone_version = utils.get_projver(bd, config.args.project, config.args.clone_version)
-        utils.clone_version(bd, proj, clone_version, config.args.version)
+        proj, version = utils.get_projver(bd, config.args.project, config.args.version)
+        if version is None:
+            proj, clone_version = utils.get_projver(bd, config.args.project, config.args.clone_version)
+            utils.clone_version(bd, proj, clone_version, config.args.version)
         
     if not config.args.cve_check_only:
         process.proc_yocto_project(config.args.manifest)


### PR DESCRIPTION
Problem:
While creating a new version, it is not possible to clone from the previous ones. As a consequence, it is not possible to move historical assessments of old vulnerabilities to the new scan. 

Solution Proposal:
with the argument called clone_version, The base version can be given as to be cloned. 
