### PR TITLE
Fix path check for default value of DEPLOYDIR

### DIFF
--- a/import_yocto_bm/config.py
+++ b/import_yocto_bm/config.py
@@ -272,8 +272,8 @@ def find_files():
         global_values.deploydir = os.path.expandvars(deploydir)
     else:
         global_values.deploydir = os.path.join(args.yocto_build_folder, "tmp", "deploy")
-    if not os.path.isdir(deploydir):
-        print("WARNING: DEPLOYDIR does not exist {}\n".format(deploydir))
+    if not os.path.isdir(global_values.deploydir):
+        print("WARNING: DEPLOYDIR does not exist {}\n".format(global_values.deploydir))
         wizlist.append('MANIFEST_FILE')
         wizlist.append('DEPLOY_DIR')
         return wizlist


### PR DESCRIPTION
In case DEPLOYDIR is not defined in the `local.conf`, `find_files` tries to use default `$BUILDDIR/tmp/deploy` and assigns this value to `global_values.deploydir`.
But, when verifying if DEPLOYDIR exists, it uses temporary variable `deploydir` reflecting value from the `local.conf`. Obviously, when DEPLOYDIR was not defined in the `localconf`, the temporary variable `deploydir` is an empty string. As a result path check always fails in case DEPLOYDIR is not set in the `local.conf`.